### PR TITLE
Adding import CSRFProtect from Google-Sign-In branch to main branch

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2,6 +2,7 @@ import os
 from flask import Flask, render_template, request, flash, redirect, url_for, flash, jsonify
 from flask_login import login_user, logout_user, login_required, current_user # login_user, logout_user is used for session management (implemented or not double check)
 from flask_dance.contrib.google import make_google_blueprint, google
+from flask_wtf.csrf import CSRFProtect
 from app import application, db
 from app.models import BillEntry, User
 from datetime import date 


### PR DESCRIPTION
CSRFProtect was not defined before in routes.py, leading to a crash when trying to do flask run (after the relevant FLASK_APP and FLASK_ENV were done). Cause of issue was that the line importing CSRFProtect from flask_wtf was accidentally deleted. 

I added back the relevant import, so it works now when you run the app.