### PR TITLE
Reverting mistakenly edited CSS styling from previously merged CSS Style Sheet Branch

### DIFF
--- a/app/templates/login-signup.html
+++ b/app/templates/login-signup.html
@@ -19,12 +19,13 @@
             margin-top: 0.25rem;
         }
     </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='js/stylesheet.css') }}">
 </head>
-<body class="bg-gray-100 font-sans min-h-screen flex items-center justify-center auth-container">
+<body class="min-h-screen flex items-center justify-center auth-container">
     <div class="max-w-md w-full mx-4">
         <!-- Logo Header -->
         <div class="text-center mb-8">
-            <h1 class="text-3xl font-extrabold text-gray-900">Meter</h1>
+            <a href="/" class="logo">Meter</a>
             <p class="mt-2 text-gray-600">Track and manage your household bills</p>
         </div>
 
@@ -60,8 +61,8 @@
             <form method="POST" action="{{ url_for('login') }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="mb-4">
-                    <label for="login-email" class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                    {{ login_form.email(class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent", id="login-email", placeholder="you@example.com") }}
+                    <label for="login-email" class="block input-label">Email</label>
+                    {{ login_form.email(class="w-full input-style", id="login-email", placeholder="you@example.com") }}
                     {% if login_form.email.errors %}
                         {% for error in login_form.email.errors %}
                             <p class="error-message">{{ error }}</p>
@@ -69,8 +70,8 @@
                     {% endif %}
                 </div>
                 <div class="mb-6">
-                    <label for="login-password" class="block text-sm font-medium text-gray-700 mb-1">Password</label>
-                    {{ login_form.password(class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent", id="login-password", placeholder="••••••••") }}
+                    <label for="login-password" class="block input-label">Password</label>
+                    {{ login_form.password(class="w-full input-label", id="login-password", placeholder="••••••••") }}
                     {% if login_form.password.errors %}
                         {% for error in login_form.password.errors %}
                             <p class="error-message">{{ error }}</p>
@@ -80,7 +81,7 @@
                         <a href="#" class="text-sm text-gray-600 hover:text-black">Forgot password?</a>
                     </div>
                 </div>
-                <button type="submit" class="w-full bg-black text-white py-2 px-4 rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-600 focus:ring-opacity-50">
+                <button type="submit" class="w-full button0">
                     Log In
                 </button>
             </form>
@@ -102,8 +103,8 @@
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
                 <div class="mb-4">
-                    <label for="signup-name" class="block text-sm font-medium text-gray-700 mb-1">Username</label>
-                    {{ reg_form.username(class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent", id="signup-name", placeholder="johnsmith") }}
+                    <label for="signup-name" class="block input-label">Username</label>
+                    {{ reg_form.username(class="w-full input-style", id="signup-name", placeholder="johnsmith") }}
                     {% if reg_form.username.errors %}
                         {% for error in reg_form.username.errors %}
                             <p class="error-message">{{ error }}</p>
@@ -112,8 +113,8 @@
                 </div>
 
                 <div class="mb-4">
-                    <label for="signup-email" class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                    {{ reg_form.email(class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent", id="signup-email", placeholder="you@example.com") }}
+                    <label for="signup-email" class="block input-label">Email</label>
+                    {{ reg_form.email(class="w-full input-style", id="signup-email", placeholder="you@example.com") }}
                     {% if reg_form.email.errors %}
                         {% for error in reg_form.email.errors %}
                             <p class="error-message">{{ error }}</p>
@@ -122,8 +123,8 @@
                 </div>
 
                 <div class="mb-4">
-                    <label for="signup-password" class="block text-sm font-medium text-gray-700 mb-1">Password</label>
-                    {{ reg_form.password(class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent", id="signup-password", placeholder="••••••••") }}
+                    <label for="signup-password" class="block input-label">Password</label>
+                    {{ reg_form.password(class="w-full input-style", id="signup-password", placeholder="••••••••") }}
                     {% if reg_form.password.errors %}
                         {% for error in reg_form.password.errors %}
                             <p class="error-message">{{ error }}</p>
@@ -133,7 +134,7 @@
                 </div>
 
                 <div class="mb-6">
-                    <label for="signup-confirm" class="block text-sm font-medium text-gray-700 mb-1">Confirm Password</label>
+                    <label for="signup-confirm" class="block input-label">Confirm Password</label>
                     {{ reg_form.confirm_password(class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent", id="signup-confirm", placeholder="••••••••") }}
                     {% if reg_form.confirm_password.errors %}
                         {% for error in reg_form.confirm_password.errors %}
@@ -155,8 +156,8 @@
 
                 <!-- New Household Code field -->
                 <div class="mb-6" id="household-code-field">
-                    <label for="household-code" class="block text-sm font-medium text-gray-700 mb-1">Household Code</label>
-                    {{ reg_form.household_code(class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent", id="household-code", placeholder="Enter code") }}
+                    <label for="household-code" class="block input-label">Household Code</label>
+                    {{ reg_form.household_code(class="w-full input-style", id="household-code", placeholder="Enter code") }}
                     {% if reg_form.household_code.errors %}
                         {% for error in reg_form.household_code.errors %}
                             <p class="error-message">{{ error }}</p>
@@ -179,7 +180,7 @@
                     document.addEventListener('DOMContentLoaded', toggleHouseholdCode);
                 </script>
 
-                <button type="submit" class="w-full bg-black text-white py-2 px-4 rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-600 focus:ring-opacity-50">
+                <button type="submit" class="w-full button0">
                     Create Account
                 </button>
             </form>


### PR DESCRIPTION
While implementing commit 91ef426 which fixed issue #55, some CSS classes were accidentally changed which reverted away from the style sheet. This commit reinstates the originals.